### PR TITLE
release 0.0.5: Update / improve the tool descriptions

### DIFF
--- a/mcpdoc/main.py
+++ b/mcpdoc/main.py
@@ -69,10 +69,7 @@ def create_server(
         
         This is the first tool you should call in the documentation workflow.
         It provides URLs to llms.txt files that the user has made available.
-        
-        Args:
-            None
-            
+                    
         Returns:
             A string containing a formatted list of documentation sources with their URLs
         """

--- a/mcpdoc/main.py
+++ b/mcpdoc/main.py
@@ -66,10 +66,10 @@ def create_server(
     @server.tool()
     def list_doc_sources() -> str:
         """List all available documentation sources.
-        
+
         This is the first tool you should call in the documentation workflow.
         It provides URLs to llms.txt files that the user has made available.
-                    
+
         Returns:
             A string containing a formatted list of documentation sources with their URLs
         """
@@ -86,15 +86,15 @@ def create_server(
     @server.tool()
     async def fetch_docs(url: str) -> str:
         """Fetch and parse documentation from a given URL.
-        
+
         Use this tool after list_doc_sources to:
         1. First fetch the llms.txt file from a documentation source
         2. Analyze the URLs listed in the llms.txt file
         3. Then fetch specific documentation pages relevant to the user's question
-        
+
         Args:
             url: The URL to fetch documentation from. Must be from an allowed domain.
-            
+
         Returns:
             The fetched documentation content converted to markdown, or an error message
             if the request fails or the URL is not from an allowed domain.

--- a/mcpdoc/main.py
+++ b/mcpdoc/main.py
@@ -41,7 +41,17 @@ def create_server(
     timeout: float = 10,
     settings: dict | None = None,
 ) -> FastMCP:
-    """Create the server and generate tools."""
+    """Create the server and generate documentation retrieval tools.
+
+    Args:
+        doc_source: List of documentation sources to make available
+        follow_redirects: Whether to follow HTTP redirects when fetching docs
+        timeout: HTTP request timeout in seconds
+        settings: Additional settings to pass to FastMCP
+
+    Returns:
+        A FastMCP server instance configured with documentation tools
+    """
     server = FastMCP(
         name="llms-txt",
         instructions=(
@@ -55,7 +65,17 @@ def create_server(
 
     @server.tool()
     def list_doc_sources() -> str:
-        """List all available doc sources. Always use this first."""
+        """List all available documentation sources.
+        
+        This is the first tool you should call in the documentation workflow.
+        It provides URLs to llms.txt files that the user has made available.
+        
+        Args:
+            None
+            
+        Returns:
+            A string containing a formatted list of documentation sources with their URLs
+        """
         content = ""
         for entry in doc_source:
             name = entry.get("name", "") or extract_domain(entry["llms_txt"])
@@ -68,9 +88,19 @@ def create_server(
 
     @server.tool()
     async def fetch_docs(url: str) -> str:
-        """Use this to fetch documentation from a given URL.
-
-        Always use list doc sources before fetching documents.
+        """Fetch and parse documentation from a given URL.
+        
+        Use this tool after list_doc_sources to:
+        1. First fetch the llms.txt file from a documentation source
+        2. Analyze the URLs listed in the llms.txt file
+        3. Then fetch specific documentation pages relevant to the user's question
+        
+        Args:
+            url: The URL to fetch documentation from. Must be from an allowed domain.
+            
+        Returns:
+            The fetched documentation content converted to markdown, or an error message
+            if the request fails or the URL is not from an allowed domain.
         """
         nonlocal allowed_domains
         if not any(url.startswith(domain) for domain in allowed_domains):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "mcpdoc"
-version = "0.0.4"
+version = "0.0.5"
 description = "Server llms-txt documentation over MCP"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ cli = [
 
 [[package]]
 name = "mcpdoc"
-version = "0.0.3"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Currently I add this workflow to Cursor. We should embed this in the tool itself.

```
use the langgraph-docs-mcp server to answer any LangGraph questions -- 
+ call list_doc_sources tool to get the available llms.txt file
+ call fetch_docs tool to read it
+ reflect on the urls in llms.txt 
+ reflect on the input question 
+ call fetch_docs on any urls relevant to the question
+ use this to answer the question
```
