### PR TITLE
fix(mcpdoc): update readme cli example and mcp json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 #### (Optional) Test the MCP server locally with your `llms.txt` file(s) of choice:
 ```bash
 uvx --from mcpdoc mcpdoc \
-    --urls LangGraph:https://langchain-ai.github.io/langgraph/llms.txt \
-    --urls LangChain:https://python.langchain.com/llms.txt \
+    --urls "LangGraph:https://langchain-ai.github.io/langgraph/llms.txt" "LangChain:https://python.langchain.com/llms.txt" \
     --transport sse \
     --port 8082 \
     --host localhost
@@ -87,9 +86,7 @@ npx @modelcontextprotocol/inspector
         "mcpdoc",
         "mcpdoc",
         "--urls",
-        "LangGraph:https://langchain-ai.github.io/langgraph/llms.txt",
-        "--urls",
-        "LangChain:https://python.langchain.com/llms.txt",
+        "LangGraph:https://langchain-ai.github.io/langgraph/llms.txt LangChain:https://python.langchain.com/llms.txt",
         "--transport",
         "stdio"
       ]


### PR DESCRIPTION
See[ this issue thread](https://github.com/langchain-ai/mcpdoc/issues/21).

Update examples in the readme to match the arg parser in `cli.py` which is configured to append multiple urls:

```python
    parser.add_argument(
        "--urls",
        "-u",
        type=str,
        nargs="+",
        help="List of llms.txt URLs or file paths with optional names (format: 'url_or_path' or 'name:url_or_path')",
    )
```

The current examples in the readme file uses multiple `--url` flags so the previous url is overridden with each new url flag.