### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   UV_NO_SYNC: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
 # There's no point in testing an outdated version of the code. GitHub only allows
 # a limited number of job runners to be active at the same time, so it's better to cancel
 # pointless jobs early so that more useful jobs can run sooner.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -35,7 +38,6 @@ jobs:
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
-    secrets: inherit
   test:
     strategy:
       matrix:
@@ -54,5 +56,4 @@ jobs:
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
-    secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ on:
         default: false
         description: "Release from a non-main branch (danger!)"
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   UV_FROZEN: "true"
@@ -105,7 +108,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true
@@ -141,7 +144,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Create Tag
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to all four workflow files (`ci.yml`, `_lint.yml`, `_test.yml`, `release.yml`) — fixes missing permissions blocks (Rules 1 & 4)
- Remove `secrets: inherit` from `ci.yml` lint and test job calls — the reusable workflows don't declare or use any secrets, so passing them in a `pull_request`-triggered context exposed repo secrets to PR head branch code (Rule 7)
- SHA-pin `pypa/gh-action-pypi-publish@release/v1` → `ed0c539` (Rule 6)
- SHA-pin `ncipollo/release-action@v1` → `339a818` (Rule 6)

## Test plan

- [x] CI passes on this PR (lint + test jobs still run correctly without `secrets: inherit`)
- [x] Verify no workflow uses `secrets: inherit` or unpinned third-party actions
- [x] Release workflow still has correct job-level escalation (`id-token: write` on publish, `contents: write` on mark-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)