### PR TITLE
fix: validate redirected fetch docs urls

### DIFF
--- a/mcpdoc/main.py
+++ b/mcpdoc/main.py
@@ -138,6 +138,11 @@ def _get_server_instructions(doc_sources: list[DocSource]) -> str:
     return "\n".join(instructions)
 
 
+def _url_allowed(url: str, domains: set[str]) -> bool:
+    """Return whether *url* starts with an allowed domain."""
+    return "*" in domains or any(url.startswith(domain) for domain in domains)
+
+
 def create_server(
     doc_sources: list[DocSource],
     *,
@@ -246,9 +251,7 @@ def create_server(
                 return f"Error reading local file: {str(e)}"
         else:
             # Otherwise treat as URL
-            if "*" not in domains and not any(
-                url.startswith(domain) for domain in domains
-            ):
+            if not _url_allowed(url, domains):
                 return (
                     "Error: URL not allowed. Must start with one of the following domains: "
                     + ", ".join(domains)
@@ -257,6 +260,12 @@ def create_server(
             try:
                 response = await httpx_client.get(url, timeout=timeout)
                 response.raise_for_status()
+                for visited_response in [*response.history, response]:
+                    if not _url_allowed(str(visited_response.url), domains):
+                        return (
+                            "Error: Redirect URL not allowed. Must start with one of the following domains: "
+                            + ", ".join(domains)
+                        )
                 content = response.text
 
                 if follow_redirects:
@@ -271,9 +280,7 @@ def create_server(
                         redirect_url = match.group(1)
                         new_url = urljoin(str(response.url), redirect_url)
 
-                        if "*" not in domains and not any(
-                            new_url.startswith(domain) for domain in domains
-                        ):
+                        if not _url_allowed(new_url, domains):
                             return (
                                 "Error: Redirect URL not allowed. Must start with one of the following domains: "
                                 + ", ".join(domains)

--- a/mcpdoc/main.py
+++ b/mcpdoc/main.py
@@ -9,8 +9,6 @@ from markdownify import markdownify
 from mcp.server.fastmcp import FastMCP
 from typing_extensions import NotRequired, TypedDict
 
-REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
-
 
 class DocSource(TypedDict):
     """A source of documentation for a library or a package."""
@@ -242,7 +240,7 @@ def create_server(
         async def fetch_allowed_url(
             current_url: str,
         ) -> tuple[httpx.Response | None, str | None]:
-            for _ in range(20):
+            for redirect_count in range(httpx_client.max_redirects + 1):
                 if not _url_allowed(current_url, domains):
                     return (
                         None,
@@ -251,10 +249,7 @@ def create_server(
                     )
 
                 response = await httpx_client.get(current_url, timeout=timeout)
-                if (
-                    not follow_redirects
-                    or response.status_code not in REDIRECT_STATUS_CODES
-                ):
+                if not follow_redirects or not response.has_redirect_location:
                     response.raise_for_status()
                     return response, None
 
@@ -262,9 +257,11 @@ def create_server(
                 if not location:
                     response.raise_for_status()
                     return response, None
+                if redirect_count == httpx_client.max_redirects:
+                    return None, "Error: Too many redirects."
                 current_url = urljoin(str(response.url), location)
 
-            return None, "Error: Too many redirects."
+            raise AssertionError("unreachable")
 
         # Handle local file paths (either as file:// URLs or direct filesystem paths)
         if not _is_http_or_https(url):

--- a/mcpdoc/main.py
+++ b/mcpdoc/main.py
@@ -9,6 +9,8 @@ from markdownify import markdownify
 from mcp.server.fastmcp import FastMCP
 from typing_extensions import NotRequired, TypedDict
 
+REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+
 
 class DocSource(TypedDict):
     """A source of documentation for a library or a package."""
@@ -172,7 +174,7 @@ def create_server(
         instructions=_get_server_instructions(doc_sources),
         **settings,
     )
-    httpx_client = httpx.AsyncClient(follow_redirects=follow_redirects, timeout=timeout)
+    httpx_client = httpx.AsyncClient(follow_redirects=False, timeout=timeout)
 
     local_sources = []
     remote_sources = []
@@ -236,6 +238,34 @@ def create_server(
     async def fetch_docs(url: str) -> str:
         nonlocal domains, follow_redirects
         url = url.strip()
+
+        async def fetch_allowed_url(
+            current_url: str,
+        ) -> tuple[httpx.Response | None, str | None]:
+            for _ in range(20):
+                if not _url_allowed(current_url, domains):
+                    return (
+                        None,
+                        "Error: Redirect URL not allowed. Must start with one of the following domains: "
+                        + ", ".join(domains),
+                    )
+
+                response = await httpx_client.get(current_url, timeout=timeout)
+                if (
+                    not follow_redirects
+                    or response.status_code not in REDIRECT_STATUS_CODES
+                ):
+                    response.raise_for_status()
+                    return response, None
+
+                location = response.headers.get("location")
+                if not location:
+                    response.raise_for_status()
+                    return response, None
+                current_url = urljoin(str(response.url), location)
+
+            return None, "Error: Too many redirects."
+
         # Handle local file paths (either as file:// URLs or direct filesystem paths)
         if not _is_http_or_https(url):
             abs_path = _normalize_path(url)
@@ -258,14 +288,10 @@ def create_server(
                 )
 
             try:
-                response = await httpx_client.get(url, timeout=timeout)
-                response.raise_for_status()
-                for visited_response in [*response.history, response]:
-                    if not _url_allowed(str(visited_response.url), domains):
-                        return (
-                            "Error: Redirect URL not allowed. Must start with one of the following domains: "
-                            + ", ".join(domains)
-                        )
+                response, error = await fetch_allowed_url(url)
+                if error:
+                    return error
+                assert response is not None
                 content = response.text
 
                 if follow_redirects:
@@ -286,8 +312,10 @@ def create_server(
                                 + ", ".join(domains)
                             )
 
-                        response = await httpx_client.get(new_url, timeout=timeout)
-                        response.raise_for_status()
+                        response, error = await fetch_allowed_url(new_url)
+                        if error:
+                            return error
+                        assert response is not None
                         content = response.text
 
                 return markdownify(content)

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1,10 +1,12 @@
 """Tests for mcpdoc.main module."""
 
+import httpx
 import pytest
 
 from mcpdoc.main import (
     _get_fetch_description,
     _is_http_or_https,
+    create_server,
     extract_domain,
 )
 
@@ -69,3 +71,85 @@ def test_get_fetch_description(has_local_sources, expected_substrings):
             # and "file://" are NOT present
             if substring in ["local file path", "file://"]:
                 assert substring not in description
+
+
+@pytest.mark.asyncio
+async def test_fetch_docs_blocks_cross_domain_http_redirect(monkeypatch) -> None:
+    """HTTP redirects must be checked against the allowed domains."""
+    async_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "http://allowed.test/redirect":
+            return httpx.Response(
+                302,
+                headers={"location": "http://blocked.test/payload"},
+                request=request,
+            )
+        if str(request.url) == "http://blocked.test/payload":
+            return httpx.Response(
+                200, text="secret from blocked origin", request=request
+            )
+        raise AssertionError(f"Unexpected request: {request.url}")
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: async_client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=kwargs.get("follow_redirects", False),
+            timeout=kwargs.get("timeout"),
+        ),
+    )
+
+    server = create_server(
+        [{"llms_txt": "http://allowed.test/llms.txt"}],
+        follow_redirects=True,
+    )
+
+    result = await server.call_tool(
+        "fetch_docs",
+        {"url": "http://allowed.test/redirect"},
+    )
+
+    text = result[0][0].text
+    assert "Error: Redirect URL not allowed." in text
+    assert "secret from blocked origin" not in text
+
+
+@pytest.mark.asyncio
+async def test_fetch_docs_allows_same_domain_http_redirect(monkeypatch) -> None:
+    """Allowed redirect targets should still return their fetched content."""
+    async_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "http://allowed.test/redirect":
+            return httpx.Response(
+                302,
+                headers={"location": "http://allowed.test/final"},
+                request=request,
+            )
+        if str(request.url) == "http://allowed.test/final":
+            return httpx.Response(200, text="<h1>Allowed docs</h1>", request=request)
+        raise AssertionError(f"Unexpected request: {request.url}")
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: async_client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=kwargs.get("follow_redirects", False),
+            timeout=kwargs.get("timeout"),
+        ),
+    )
+
+    server = create_server(
+        [{"llms_txt": "http://allowed.test/llms.txt"}],
+        follow_redirects=True,
+    )
+
+    result = await server.call_tool(
+        "fetch_docs",
+        {"url": "http://allowed.test/redirect"},
+    )
+
+    assert "Allowed docs" in result[0][0].text

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -211,3 +211,78 @@ async def test_fetch_docs_allows_same_domain_http_redirect(monkeypatch) -> None:
     )
 
     assert "Allowed docs" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_fetch_docs_stops_after_twenty_redirects(monkeypatch) -> None:
+    """Redirect chains must be bounded."""
+    async_client = httpx.AsyncClient
+    requested_urls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return httpx.Response(
+            302,
+            headers={"location": f"/redirect/{len(requested_urls)}"},
+            request=request,
+        )
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: async_client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=kwargs.get("follow_redirects", False),
+            timeout=kwargs.get("timeout"),
+        ),
+    )
+
+    server = create_server(
+        [{"llms_txt": "http://allowed.test/llms.txt"}],
+        follow_redirects=True,
+    )
+    result = await server.call_tool(
+        "fetch_docs",
+        {"url": "http://allowed.test/redirect"},
+    )
+
+    assert "Error: Too many redirects." in result[0][0].text
+    assert len(requested_urls) == 20
+
+
+@pytest.mark.asyncio
+async def test_fetch_docs_does_not_follow_304_location(monkeypatch) -> None:
+    """A 304 response with Location is not an HTTP redirect."""
+    async_client = httpx.AsyncClient
+    requested_urls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return httpx.Response(
+            304,
+            headers={"location": "http://blocked.test/payload"},
+            text="<h1>Not redirected</h1>",
+            request=request,
+        )
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: async_client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=kwargs.get("follow_redirects", False),
+            timeout=kwargs.get("timeout"),
+        ),
+    )
+
+    server = create_server(
+        [{"llms_txt": "http://allowed.test/llms.txt"}],
+        follow_redirects=True,
+    )
+    result = await server.call_tool(
+        "fetch_docs",
+        {"url": "http://allowed.test/not-modified"},
+    )
+
+    assert "304 Not Modified" in result[0][0].text
+    assert requested_urls == ["http://allowed.test/not-modified"]

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -214,13 +214,18 @@ async def test_fetch_docs_allows_same_domain_http_redirect(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_docs_stops_after_twenty_redirects(monkeypatch) -> None:
-    """Redirect chains must be bounded."""
+@pytest.mark.parametrize(("redirects", "succeeds"), [(20, True), (21, False)])
+async def test_fetch_docs_redirect_limit_matches_httpx(
+    monkeypatch, redirects, succeeds
+) -> None:
+    """Allow 20 redirects and reject the 21st, matching httpx."""
     async_client = httpx.AsyncClient
     requested_urls = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requested_urls.append(str(request.url))
+        if len(requested_urls) > redirects:
+            return httpx.Response(200, text="<h1>Final docs</h1>", request=request)
         return httpx.Response(
             302,
             headers={"location": f"/redirect/{len(requested_urls)}"},
@@ -246,8 +251,11 @@ async def test_fetch_docs_stops_after_twenty_redirects(monkeypatch) -> None:
         {"url": "http://allowed.test/redirect"},
     )
 
-    assert "Error: Too many redirects." in result[0][0].text
-    assert len(requested_urls) == 20
+    if succeeds:
+        assert "Final docs" in result[0][0].text
+    else:
+        assert "Error: Too many redirects." in result[0][0].text
+    assert len(requested_urls) == 21
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -77,8 +77,10 @@ def test_get_fetch_description(has_local_sources, expected_substrings):
 async def test_fetch_docs_blocks_cross_domain_http_redirect(monkeypatch) -> None:
     """HTTP redirects must be checked against the allowed domains."""
     async_client = httpx.AsyncClient
+    requested_urls = []
 
     def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
         if str(request.url) == "http://allowed.test/redirect":
             return httpx.Response(
                 302,
@@ -114,6 +116,62 @@ async def test_fetch_docs_blocks_cross_domain_http_redirect(monkeypatch) -> None
     text = result[0][0].text
     assert "Error: Redirect URL not allowed." in text
     assert "secret from blocked origin" not in text
+    assert requested_urls == ["http://allowed.test/redirect"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_docs_blocks_meta_refresh_redirect_chain(monkeypatch) -> None:
+    """Meta-refresh follow-up redirects must be checked before fetching."""
+    async_client = httpx.AsyncClient
+    requested_urls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        if str(request.url) == "http://allowed.test/page":
+            return httpx.Response(
+                200,
+                text='<meta http-equiv="refresh" content="0; url=/next">',
+                request=request,
+            )
+        if str(request.url) == "http://allowed.test/next":
+            return httpx.Response(
+                302,
+                headers={"location": "http://blocked.test/payload"},
+                request=request,
+            )
+        if str(request.url) == "http://blocked.test/payload":
+            return httpx.Response(
+                200, text="secret from blocked origin", request=request
+            )
+        raise AssertionError(f"Unexpected request: {request.url}")
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: async_client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=kwargs.get("follow_redirects", False),
+            timeout=kwargs.get("timeout"),
+        ),
+    )
+
+    server = create_server(
+        [{"llms_txt": "http://allowed.test/llms.txt"}],
+        follow_redirects=True,
+    )
+
+    result = await server.call_tool(
+        "fetch_docs",
+        {"url": "http://allowed.test/page"},
+    )
+
+    text = result[0][0].text
+    assert "Error: Redirect URL not allowed." in text
+    assert "secret from blocked origin" not in text
+    assert requested_urls == [
+        "http://allowed.test/page",
+        "http://allowed.test/next",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- disable httpx's automatic redirect following and validate every HTTP redirect target before issuing the next request
- route meta-refresh follow-up requests through the same checked redirect loop
- preserve httpx's redirect limit semantics and ignore non-redirect responses such as 304 responses with a `Location` header
- cover allowed and blocked hops, meta-refresh chains, redirect limits, and 304 handling

Closes #68.

## Validation

- `PYTHONPATH=. python3 -m pytest tests/unit_tests -q` - 15 passed
- `python3 -m ruff check mcpdoc/main.py tests/unit_tests/test_main.py` - passed
- `python3 -m ruff format --check mcpdoc/main.py tests/unit_tests/test_main.py` - passed

## Risk

The change is limited to `fetch_docs` redirect handling. Local file access and wildcard `allowed_domains=["*"]` behavior are unchanged. Disallowed redirect targets are rejected before a network request is sent.